### PR TITLE
Feature: Added shortcode attribute for post ID

### DIFF
--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -779,8 +779,17 @@ class BSFRT_ReadTime {
 	 * @since 1.0.0
 	 * @return shortcode display value.
 	 */
-	public function read_meter_shortcode() {
+	public function read_meter_shortcode( $atts ) {
+		$atts = shortcode_atts( array(
+			'id' => ''
+		), $atts, 'read_meter' );
+		
 		$bsf_rt_post = get_the_ID();
+		if ( isset( $atts['id'] ) && ! empty( $atts['id'] ) && is_numeric( $atts['id'] ) ) {
+			if ( $post = get_post( sanitize_text_field( $atts['id'] ) ) ) {
+				$bsf_rt_post = $post->ID;
+			}
+		}
 
 		$this->bsf_rt_calculate_reading_time( $bsf_rt_post, $this->bsf_rt_options );
 

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -777,6 +777,7 @@ class BSFRT_ReadTime {
 	 * Function of the read_meter shortcode.
 	 *
 	 * @since 1.0.0
+	 * @param array $atts Optional associative array of attributes for the shortcode.
 	 * @return shortcode display value.
 	 */
 	public function read_meter_shortcode( $atts ) {

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -786,8 +786,9 @@ class BSFRT_ReadTime {
 		), $atts, 'read_meter' );
 		
 		$bsf_rt_post = get_the_ID();
-		if ( isset( $atts['id'] ) && ! empty( $atts['id'] ) && is_numeric( $atts['id'] ) ) {
-			if ( $post = get_post( sanitize_text_field( $atts['id'] ) ) ) {
+		if ( ! empty( $atts['id'] ) && is_numeric( $atts['id'] ) ) {
+			$post = get_post( sanitize_text_field( $atts['id'] ) );
+			if ( $post ) {
 				$bsf_rt_post = $post->ID;
 			}
 		}


### PR DESCRIPTION
Added `id` attribute for the `[read-meter]` shortcode.

Task: In the Read Meter Shortcode `[read_meter]`, we want to accept page/post ID eg: `[read_meter id="43"]` & show reading time of that particular post irrespective of where the shortcode is added.

Usecases mentioned by user:
Case 1: Need to build a custom query, and loop item for custom view (Post image, Post title, Read Time, Link to post).
Case 2: Need to show "similar posts" with read time (pretty the same case like first one).

Test Video:

https://github.com/brainstormforce/read-meter/assets/159872083/d8e923a3-fa1b-4eca-b2fb-8797065643f8


