### PR TITLE
Version 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.2  
 **Requires PHP:** 5.2  
 **Tested up to:** 6.5  
-**Stable tag:** 1.0.8  
+**Stable tag:** 1.0.9  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -76,6 +76,10 @@ The Read Meter plugin works with all WordPress themes!
 4. Getting Started
 
 ## Changelog ##
+### 1.0.9 ###
+- Feature: Added the ID attribute to the `[read_meter]` shortcode eg: `[read_meter id="47"]` to show reading time of that particular post/page irrespective of where the shortcode is added.
+- Fix: Reading time using shortcode `[read_meter]` was not visible on individual post/page unless the post type was selected.
+
 ### 1.0.8 ###
 - Fix: Page Content Wrap Marker used for progress bar was causing styling issues with non block based themes.
 - Fix: Only added the marker needed for progress bar on the post types selected.

--- a/bsf-readtime.php
+++ b/bsf-readtime.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Read Meter - Reading Time & Progress Bar for WordPress.
  * Description:  To display Reading Time for a particular post.
- * Version:     1.0.8
+ * Version:     1.0.9
  * Author:      Brainstorm Force
  * Author URI:  https://brainstormforce.com
  * Text Domain: read-meter.
@@ -19,7 +19,7 @@
 
 define( 'BSF_RT_PATH', __FILE__ );
 
-define( 'BSF_RT_VER', '1.0.8' );
+define( 'BSF_RT_VER', '1.0.9' );
 
 define( 'BSF_RT_ABSPATH', plugin_dir_path( __FILE__ ) );
 

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -1192,7 +1192,7 @@ min-width: 100px;
 	/**
 	 * Helper function to add frontend default CSS.
 	 * 
-	 * @since x.x.x
+	 * @since 1.0.9
 	 */
 	public function bsf_rt_add_default_frontend_css() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'bsfrt_frontend_default_css' ) );
@@ -1201,7 +1201,7 @@ min-width: 100px;
 	/**
 	 * Helper function to add readtime styles content CSS.
 	 * 
-	 * @since x.x.x
+	 * @since 1.0.9
 	 */
 	public function bsf_rt_add_readtime_styles_content() {
 		add_action( 'wp_head', array( $this, 'bsf_rt_set_readtime_styles_content' ) );

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -38,11 +38,18 @@ class BSFRT_ReadTime {
 	public $bsf_rt_options = array();
 
 	/**
-	 * Member Varaible
+	 * Member Variable
 	 *
 	 * @var bsf_rt_check_the_page
 	 */
 	public static $bsf_rt_check_the_page;
+
+	/**
+	 * Member Variable
+	 * 
+	 * @var bsf_rt_styles_loaded_flag
+	 */
+	private $bsf_rt_styles_loaded_flag = false;
 
 	/**
 	 * Initiator
@@ -183,19 +190,26 @@ class BSFRT_ReadTime {
 	 * Frontend settings.
 	 */
 	public function bsf_rt_init_frontend() {
+		global $post;
+		if ( ! empty( $post ) && has_shortcode( $post->post_content, 
+ 'read_meter' ) ) {
+			$this->bsf_rt_add_default_frontend_css();
+			$this->bsf_rt_add_readtime_styles_content();
+			$this->bsf_rt_styles_loaded_flag = true;
+		}
 
 		if ( false === $this->bsf_rt_check_selected_post_types() ) {
 
 			return;
 		}
-		add_action( 'wp_enqueue_scripts', array( $this, 'bsfrt_frontend_default_css' ) );
+		$this->bsf_rt_add_default_frontend_css();
 		add_filter( 'comments_template', array( $this, 'bsf_rt_marker_for_progressbar' ) );
 
 		if ( 'none' !== $this->bsf_rt_get_option( 'bsf_rt_position_of_read_time' ) ) {
 
-			if ( 'above_the_content' === $this->bsf_rt_get_option( 'bsf_rt_position_of_read_time' ) ) {
+			if ( 'above_the_content' === $this->bsf_rt_get_option( 'bsf_rt_position_of_read_time' ) && ! $this->bsf_rt_styles_loaded_flag ) {
 				// Read time styles.
-				add_action( 'wp_head', array( $this, 'bsf_rt_set_readtime_styles_content' ) );
+				$this->bsf_rt_add_readtime_styles_content();
 			} else {
 
 				add_action( 'wp_head', array( $this, 'bsf_rt_set_readtime_styles' ) );
@@ -265,6 +279,7 @@ class BSFRT_ReadTime {
 				}
 			}
 		}
+
 		// Displaying Progress Bar Conditions.
 		if ( 'none' === $this->bsf_rt_get_option( 'bsf_rt_position_of_progress_bar' ) ) {
 
@@ -624,7 +639,7 @@ class BSFRT_ReadTime {
 	 * Calculate the reading time of a post.
 	 *
 	 * Gets the post content, counts the images, strips shortcodes, and strips tags.
-	 * Then counds the words. Converts images into a word coun and outputs the total reading time.
+	 * Then counts the words. Converts images into a word count and outputs the total reading time.
 	 *
 	 * @since 1.0.0
 	 * @param  int   $bsf_rt_post The Post ID.
@@ -1153,8 +1168,8 @@ min-width: 100px;
 	 * Marker for progress bar
 	 *
 	 * @param string $template input of the filter.
-	 * @return string $template for the purpose to execute comments.
 	 * @since  1.1.0
+	 * @return string $template for the purpose to execute comments.
 	 */
 	public function bsf_rt_marker_for_progressbar( $template ) {
 		echo '<div id="bsf-rt-comments"></div>';
@@ -1163,7 +1178,23 @@ min-width: 100px;
 				return $template;
 	}
 
+	/**
+	 * Helper function to add frontend default CSS.
+	 * 
+	 * @since x.x.x
+	 */
+	public function bsf_rt_add_default_frontend_css() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'bsfrt_frontend_default_css' ) );
+	}
 
+	/**
+	 * Helper function to add readtime styles content CSS.
+	 * 
+	 * @since x.x.x
+	 */
+	public function bsf_rt_add_readtime_styles_content() {
+		add_action( 'wp_head', array( $this, 'bsf_rt_set_readtime_styles_content' ) );
+	}
 
 }
 

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -778,10 +778,21 @@ class BSFRT_ReadTime {
 	 * Function of the read_meter shortcode.
 	 *
 	 * @since 1.0.0
+	 * @param array $atts Optional associative array of attributes for the shortcode.
 	 * @return shortcode display value.
 	 */
-	public function read_meter_shortcode() {
+	public function read_meter_shortcode( $atts ) {
+		$atts = shortcode_atts( array(
+			'id' => ''
+		), $atts, 'read_meter' );
+		
 		$bsf_rt_post = get_the_ID();
+		if ( ! empty( $atts['id'] ) && is_numeric( $atts['id'] ) ) {
+			$post = get_post( sanitize_text_field( $atts['id'] ) );
+			if ( $post ) {
+				$bsf_rt_post = $post->ID;
+			}
+		}
 
 		$this->bsf_rt_calculate_reading_time( $bsf_rt_post, $this->bsf_rt_options );
 

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -1003,7 +1003,7 @@ class BSFRT_ReadTime {
 	min-width: 100px;
 
 	}
-</style>
+
 		<?php
 	}
 

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -1003,7 +1003,7 @@ class BSFRT_ReadTime {
 	min-width: 100px;
 
 	}
-
+</style>
 		<?php
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,13 @@
 {
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-        "wp-coding-standards/wpcs": "dev-master",
-        "phpcompatibility/phpcompatibility-wp": "^2.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "wp-coding-standards/wpcs": "^3.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.0",
+        "phpcompatibility/php-compatibility": "^9.0"
     },
-    "require": {
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77309a9d2af0fc503d50398a7fcf61c3",
+    "content-hash": "23aa8cb41b5a126342f1bbee036dade5",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -49,13 +47,17 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -63,6 +65,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -73,20 +76,24 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.1.1",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +107,7 @@
                 "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -110,10 +117,6 @@
             ],
             "authors": [
                 {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
-                },
-                {
                     "name": "Wim Godden",
                     "homepage": "https://github.com/wimg",
                     "role": "lead"
@@ -122,6 +125,10 @@
                     "name": "Juliette Reinders Folmer",
                     "homepage": "https://github.com/jrfnl",
                     "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
                 }
             ],
             "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
@@ -131,30 +138,36 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-30T23:16:27+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.0.1",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea"
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/9160de79fcd683b5c99e9c4133728d91529753ea",
-                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -179,22 +192,42 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
-            "time": "2018-12-16T19:10:44+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:30:46+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.0.0",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
-                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
+                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
                 "shasum": ""
             },
             "require": {
@@ -202,10 +235,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -229,22 +262,208 @@
                 "compatibility",
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
-            "time": "2018-10-07T18:31:37+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:37:59+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T11:47:18+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
                 "shasum": ""
             },
             "require": {
@@ -254,11 +473,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -273,42 +492,80 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-23T20:25:34+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "dev-master",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.10",
+                "squizlabs/php_codesniffer": "^3.9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -318,25 +575,36 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-03-25T16:39:00+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "wp-coding-standards/wpcs": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/bsf-rt-user-manual.php
+++ b/includes/bsf-rt-user-manual.php
@@ -19,6 +19,7 @@ wp_enqueue_style( 'bsfrt_dashboard' );
 	<b>Step 3</b> : Go to the <i>Progress Bar</i> Tab, and select the position, colors, and thickness of the progress bar as per your need. <br><br>
 	<b>Step 4</b> :That' . "'" . 's it! Visit Post/Page to see results.  <br><br><br>
 	<b> Shortcode : [read_meter]</b> <br><br>
-		You can also display the reading time wherever you want by using this shortcode , You just need to copy it and paste it in any content of Post or Page.';
+		You can also display the reading time wherever you want by using this shortcode , You just need to copy it and paste it in any content of Post or Page. <br>
+		You can provide a simple ID attribute to the shortcode to display reading time of that particular post/page irrespective of where the shortcode is added, eg: <b>[read_meter id=47]</b>.';
 		?>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "read-meter",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "read-meter",
-      "version": "1.0.6",
+      "version": "1.0.9",
       "devDependencies": {
         "autoprefixer": "^9.6.1",
         "grunt": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "read-meter",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,7 @@ It works great to give visitors a quick idea about the time needed to read a pos
 Here are some key features of the plugin -
 
 + A simple shortcode - `[read_meter]`,  gives you the flexibility to add read time anywhere on the site.
++ A simple ID attribute to the shortcode can display reading time of that particular post/page irrespective of where the shortcode is added - `[read_meter id=47]`.
 + Even if the post is updated multiple times, the plugin will calculate the read time for the most recent version of the post.
 + You can choose to display the read time and a progress bar on various post types.
 + You can decide whether you would like to include images and comments in the read time and progress bar.
@@ -37,6 +38,7 @@ Here are some key features of the plugin -
 That's not all! Here are some more controls you get over **Reading Time** -
 
 + Display the read time on a blog/archive page or single post page
++ Show the estimated time it takes to read any blog/archive page or single post page, which can be displayed on any section of the website
 + Set the read time position - i.e. Above/Below title or above content
 + Set a read time Prefix and Postfix
 + Use various read time styling options - Spacing, Background color, Font size, etc.
@@ -76,6 +78,10 @@ The Read Meter plugin works with all WordPress themes!
 4. Getting Started
 
 == Changelog ==
+= 1.0.9 =
+- Feature: Added the ID attribute to the `[read_meter]` shortcode eg: `[read_meter id="47"]` to show reading time of that particular post/page irrespective of where the shortcode is added.
+- Fix: Reading time using shortcode `[read_meter]` was not visible on individual post/page unless the post type was selected.
+
 = 1.0.8 =
 - Fix: Page Content Wrap Marker used for progress bar was causing styling issues with non block based themes.
 - Fix: Only added the marker needed for progress bar on the post types selected.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: readtime, progressbar
 Requires at least: 4.2
 Requires PHP: 5.2
 Tested up to: 6.5
-Stable tag: 1.0.8
+Stable tag: 1.0.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## 1.0.9 - Thursday, 2nd May 2024

- Feature: Added the ID attribute to the `[read_meter]` shortcode eg: `[read_meter id="47"]` to show reading time of that particular post/page irrespective of where the shortcode is added.
- Fix: Reading time using shortcode `[read_meter]` was not visible on individual post/page unless the post type was selected.


https://github.com/brainstormforce/read-meter/assets/159872083/4cf7b5b4-4ade-4b1b-b55c-42abb8699271

