### PR TITLE
Improvement: Updated the plugin description to include the new feature of shortcode ID

### DIFF
--- a/includes/bsf-rt-user-manual.php
+++ b/includes/bsf-rt-user-manual.php
@@ -19,6 +19,7 @@ wp_enqueue_style( 'bsfrt_dashboard' );
 	<b>Step 3</b> : Go to the <i>Progress Bar</i> Tab, and select the position, colors, and thickness of the progress bar as per your need. <br><br>
 	<b>Step 4</b> :That' . "'" . 's it! Visit Post/Page to see results.  <br><br><br>
 	<b> Shortcode : [read_meter]</b> <br><br>
-		You can also display the reading time wherever you want by using this shortcode , You just need to copy it and paste it in any content of Post or Page.';
+		You can also display the reading time wherever you want by using this shortcode , You just need to copy it and paste it in any content of Post or Page. <br>
+		You can provide a simple ID attribute to the shortcode to display reading time of that particular post/page irrespective of where the shortcode is added, eg: <b>[read_meter id=47]</b>.';
 		?>
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,7 @@ It works great to give visitors a quick idea about the time needed to read a pos
 Here are some key features of the plugin -
 
 + A simple shortcode - `[read_meter]`,  gives you the flexibility to add read time anywhere on the site.
++ A simple ID attribute to the shortcode can display reading time of that particular post/page irrespective of where the shortcode is added - `[read_meter id=47]`.
 + Even if the post is updated multiple times, the plugin will calculate the read time for the most recent version of the post.
 + You can choose to display the read time and a progress bar on various post types.
 + You can decide whether you would like to include images and comments in the read time and progress bar.
@@ -37,6 +38,7 @@ Here are some key features of the plugin -
 That's not all! Here are some more controls you get over **Reading Time** -
 
 + Display the read time on a blog/archive page or single post page
++ Display the read time of any blog/archive page or single post page anywhere on the site
 + Set the read time position - i.e. Above/Below title or above content
 + Set a read time Prefix and Postfix
 + Use various read time styling options - Spacing, Background color, Font size, etc.
@@ -76,6 +78,10 @@ The Read Meter plugin works with all WordPress themes!
 4. Getting Started
 
 == Changelog ==
+= 1.0.9 =
+- Feature: Added the ID attribute to the `[read_meter]` shortcode eg: `[read_meter id="47"]` to show reading time of that particular post/page irrespective of where the shortcode is added.
+- Fix: Reading time using shortcode `[read_meter]` was not visible on individual post/page unless the post type was selected.
+
 = 1.0.8 =
 - Fix: Page Content Wrap Marker used for progress bar was causing styling issues with non block based themes.
 - Fix: Only added the marker needed for progress bar on the post types selected.

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ Here are some key features of the plugin -
 That's not all! Here are some more controls you get over **Reading Time** -
 
 + Display the read time on a blog/archive page or single post page
-+ Display the read time of any blog/archive page or single post page anywhere on the site
++ Show the estimated time it takes to read any blog/archive page or single post page, which can be displayed on any section of the website
 + Set the read time position - i.e. Above/Below title or above content
 + Set a read time Prefix and Postfix
 + Use various read time styling options - Spacing, Background color, Font size, etc.


### PR DESCRIPTION
Updated the plugin description to include the usage of the shortcode ID attribute to display the reading time of any post/page according to it's ID, below is the image for the "Getting Started" section of the plugin.

![image](https://github.com/brainstormforce/read-meter/assets/159872083/c8c6f1d2-3c34-4473-92a1-d4aedc04d266)
