### PR TITLE
Missing closing <style> tag

### DIFF
--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -1003,7 +1003,7 @@ class BSFRT_ReadTime {
 	min-width: 100px;
 
 	}
-
+</style>
 		<?php
 	}
 


### PR DESCRIPTION
**Description**
The Read Meter plugin is causing the website built using Elementor page builder to crash. (You can check with Astra's fresh setup as well)

Steps to reproduce the issue
1. Install the Read Meter plugin
2. Go to Settings > Read Meter to access its settings
3. Go to the Read Time tab and select either " Above Post Title" or " Below Post Title"
4. Save and check the homepage, you'll see it's broken and logged out

**Video Ref:** https://cdn-std.droplr.net/files/acc_1304690/44thjw

After applying the solution: https://d.pr/v/e9jtMT