### PR TITLE
Improve I18N Issues Based on 1.0.11

### DIFF
--- a/bsf-readtime.php
+++ b/bsf-readtime.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Plugin Name: Read Meter - Reading Time & Progress Bar for WordPress.
+ * Plugin Name: Read Meter - Reading Time & Progress Bar for WordPress
  * Description:  To display Reading Time for a particular post.
  * Version:     1.0.11
  * Author:      Pratik Chaskar
  * Author URI:  https://pratikchaskar.com
- * Text Domain: read-meter.
+ * Text Domain: read-meter
  * Main
  *
  * PHP version 7

--- a/classes/class-bsfrt-readtime.php
+++ b/classes/class-bsfrt-readtime.php
@@ -119,8 +119,8 @@ class BSFRT_ReadTime {
 
 		$default_options_readtime = array(
 			'bsf_rt_show_read_time'             => $bsf_rt_show_read_time,
-			'bsf_rt_reading_time_label'         => 'Reading Time',
-			'bsf_rt_reading_time_postfix_label' => 'mins',
+			'bsf_rt_reading_time_label'         => __( 'Reading Time', 'read-meter'),
+			'bsf_rt_reading_time_postfix_label' => __( 'mins', 'read-meter'),
 			'bsf_rt_words_per_minute'           => '275',
 			'bsf_rt_position_of_read_time'      => 'above_the_content',
 			'bsf_rt_read_time_background_color' => '#eeeeee',

--- a/includes/bsf-rt-general-settings.php
+++ b/includes/bsf-rt-general-settings.php
@@ -33,13 +33,13 @@ $exclude = array( 'attachment', 'elementor_library', 'Media', 'My Templates' );
 		<br>
 		<p class="description">
 				<?php
-				esc_attr_e( 'Control the core settings of a read meter, e.g. the average count of words that humans can read in a minute & allow a read meter on particular post types, etc.', 'read-meter' );
+				esc_html_e( 'Control the core settings of a read meter, e.g. the average count of words that humans can read in a minute & allow a read meter on particular post types, etc.', 'read-meter' );
 				?>
 			   
 		</p>  
 		<tr>
 	<th scope="row">
-			<label for="SelectPostTypes"><?php esc_attr_e( 'Select Post Types', 'read-meter' ); ?> :</label>
+			<label for="SelectPostTypes"><?php esc_html_e( 'Select Post Types:', 'read-meter' ); ?></label>
 			</th>
 			<td class="post_type_name">
 				   
@@ -84,7 +84,7 @@ $exclude = array( 'attachment', 'elementor_library', 'Media', 'My Templates' );
 		<tr>
 		<tr>
 		<th scope="row">
-			<label for="WordsPerMinute"><?php esc_attr_e( 'Words Per Minute', 'read-meter' ); ?> :</label>
+			<label for="WordsPerMinute"><?php esc_html_e( 'Words Per Minute:', 'read-meter' ); ?></label>
 		</th>
 		<td>
 			<?php
@@ -94,7 +94,7 @@ $exclude = array( 'attachment', 'elementor_library', 'Media', 'My Templates' );
 		</tr>
 		<th scope="row">
 
-			<label for="IncludeComments"> <?php esc_attr_e( 'Include Comments', 'read-meter' ); ?> :</label>
+			<label for="IncludeComments"> <?php esc_html_e( 'Include Comments:', 'read-meter' ); ?></label>
 		</th>
 		<td>
 				<?php
@@ -105,7 +105,7 @@ $exclude = array( 'attachment', 'elementor_library', 'Media', 'My Templates' );
 				}
 				?>
 			<p  class="description bsf_rt_description">
-					<?php esc_attr_e( "Check this to include comment's text in reading time.", 'read-meter' ); ?>
+					<?php esc_html_e( "Check this to include comment's text in reading time.", 'read-meter' ); ?>
 
 			</p>  
 		</td>
@@ -113,7 +113,7 @@ $exclude = array( 'attachment', 'elementor_library', 'Media', 'My Templates' );
 <tr>
 		<th scope="row">
 
-			<label for="IncludeImages"> <?php esc_attr_e( 'Include Images', 'read-meter' ); ?> :</label>
+			<label for="IncludeImages"> <?php esc_html_e( 'Include Images:', 'read-meter' ); ?></label>
 		</th>
 		<td>
 			<?php
@@ -126,7 +126,7 @@ $exclude = array( 'attachment', 'elementor_library', 'Media', 'My Templates' );
 			}
 			?>
 			<p  class="description bsf_rt_description">   
-				<?php esc_attr_e( ' Check this to include post images in reading time.', 'read-meter' ); ?>  
+				<?php esc_html_e( ' Check this to include post images in reading time.', 'read-meter' ); ?>  
 			</p>  
 		</td>
 		</tr>
@@ -135,7 +135,7 @@ $exclude = array( 'attachment', 'elementor_library', 'Media', 'My Templates' );
 	<tr>
 		<th>
 			<?php wp_nonce_field( 'bsf-rt-nonce-general', 'bsf-rt-general' ); ?>
-			<input type="submit" value="Save" class="bt button button-primary" name="submit">
+			<input type="submit" value="<?php esc_attr_e( 'Save', 'read-meter' ); ?>" class="bt button button-primary" name="submit">
 		</th>
 	</tr>
 	</table>

--- a/includes/bsf-rt-main-frontend.php
+++ b/includes/bsf-rt-main-frontend.php
@@ -9,14 +9,14 @@
 
 wp_enqueue_style( 'bsfrt_dashboard' );
 echo '<h1 class="bsf_rt_main_title">';
-esc_attr_e( 'Read Meter', 'read-meter' );
+esc_html_e( 'Read Meter', 'read-meter' );
 echo '</h1>';
 
 if ( 'ok' == get_option( 'bsf_rt_saved_msg' ) ) { //PHPCS:ignore:WordPress.PHP.StrictComparisons.LooseComparison
 	echo '<div id="message" class="notice is-dismissible notice-success">
-      <p class="description">
-      Settings Saved.
-      </p>
+      <p class="description">' .
+      esc_html__( 'Settings Saved.', 'read-meter' )
+      . '</p>
     </div>';
 	update_option( 'bsf_rt_saved_msg', 'notok' );
 }
@@ -57,7 +57,7 @@ if ( isset( $_GET['tab'] ) ) {//PHPCS:ignore:WordPress.Security.NonceVerificatio
 					echo 'nav-tab-active';
 	}
 	?>
-	"><?php esc_attr_e( 'General Settings', 'read-meter' ); ?></a>
+	"><?php esc_html_e( 'General Settings', 'read-meter' ); ?></a>
 
 			<a href="?page=bsf_rt&tab=bsf_rt_read_time_settings" class="nav-tab tb 
 			<?php
@@ -65,7 +65,7 @@ if ( isset( $_GET['tab'] ) ) {//PHPCS:ignore:WordPress.Security.NonceVerificatio
 					echo 'nav-tab-active';
 			}
 			?>
-			"><?php esc_attr_e( 'Read Time', 'read-meter' ); ?></a>
+			"><?php esc_html_e( 'Read Time', 'read-meter' ); ?></a>
 
 			<a href="?page=bsf_rt&tab=bsf_rt_progress_bar_settings" class="nav-tab tb 
 			<?php
@@ -73,7 +73,7 @@ if ( isset( $_GET['tab'] ) ) {//PHPCS:ignore:WordPress.Security.NonceVerificatio
 						echo 'nav-tab-active';
 			}
 			?>
-			"><?php esc_attr_e( 'Progress Bar', 'read-meter' ); ?></a>
+			"><?php esc_html_e( 'Progress Bar', 'read-meter' ); ?></a>
 
 		<a href="?page=bsf_rt&tab=bsf_rt_user_manual" class="nav-tab tb 
 		<?php
@@ -81,7 +81,7 @@ if ( isset( $_GET['tab'] ) ) {//PHPCS:ignore:WordPress.Security.NonceVerificatio
 						echo 'nav-tab-active';
 		}
 		?>
-		"><?php esc_attr_e( 'Getting Started', 'read-meter' ); ?></a>
+		"><?php esc_html_e( 'Getting Started', 'read-meter' ); ?></a>
 </h2>
 
 <?php

--- a/includes/bsf-rt-progress-bar-settings.php
+++ b/includes/bsf-rt-progress-bar-settings.php
@@ -35,12 +35,12 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 	<table class="form-table">
 		<br>
 		<p class="description">
-			<?php esc_attr_e( 'Control the position & appearance of the progress bar. Progress bar acts with the content that the user has read. (Note : The Progress Bar will only display on Singular Posts or Pages)', 'bsf_rt_textdomain' ); ?>
+			<?php esc_html_e( 'Control the position & appearance of the progress bar. Progress bar acts with the content that the user has read. (Note : The Progress Bar will only display on Singular Posts or Pages)', 'read-meter' ); ?>
 		</p> 
 		<tr>
 		<th scope="row"> 
 
-			<label for="PositionofDisplayProgressBar"><?php esc_attr_e( 'Display Position', 'bsf_rt_textdomain' ); ?> :</label>
+			<label for="PositionofDisplayProgressBar"><?php esc_html_e( 'Display Position:', 'read-meter' ); ?></label>
 
 		</th>
 		<td>
@@ -51,45 +51,45 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 					if ( 'top_of_the_page' === $bsf_rt_position_of_progress_bar ) {
 
 						echo '<option selected value="top_of_the_page">';
-						esc_attr_e( 'Top of the Page', 'bsf_rt_textdomain' );
+						esc_html_e( 'Top of the Page', 'read-meter' );
 						echo '</option>';
 					} else {
 
 						echo '<option  value="top_of_the_page">';
-						esc_attr_e( 'Top of the Page', 'bsf_rt_textdomain' );
+						esc_html_e( 'Top of the Page', 'read-meter' );
 						echo '</option>';
 					}
 					if ( 'bottom_of_the_page' === $bsf_rt_position_of_progress_bar ) {
 
 						echo '<option selected value="bottom_of_the_page">';
-						esc_attr_e( 'Bottom of the Page', 'bsf_rt_textdomain' );
+						esc_html_e( 'Bottom of the Page', 'read-meter' );
 						echo '</option>';
 					} else {
 
 						echo '<option  value="bottom_of_the_page">';
-						esc_attr_e( 'Bottom of the Page', 'bsf_rt_textdomain' );
+						esc_html_e( 'Bottom of the Page', 'read-meter' );
 						echo '</option>';
 					}
 					if ( 'none' === $bsf_rt_position_of_progress_bar ) {
 
 						echo '<option selected value="none">';
-						esc_attr_e( 'None', 'bsf_rt_textdomain' );
+						esc_html_e( 'None', 'read-meter' );
 						echo '</option>';
 					} else {
 
 						echo '<option  value="none">';
-						esc_attr_e( 'None', 'bsf_rt_textdomain' );
+						esc_html_e( 'None', 'read-meter' );
 						echo '</option>';
 					}
 				} else {
 					echo '<option  value="none">';
-						esc_attr_e( 'None', 'bsf_rt_textdomain' );
+						esc_html_e( 'None', 'read-meter' );
 						echo '</option>';
 					echo '<option  value="top_of_the_page">';
-						esc_attr_e( 'Top of the Page', 'bsf_rt_textdomain' );
+						esc_html_e( 'Top of the Page', 'read-meter' );
 						echo '</option>';
 					echo '<option  value="bottom_of_the_page">';
-						esc_attr_e( 'Bottom of the Page', 'bsf_rt_textdomain' );
+						esc_html_e( 'Bottom of the Page', 'read-meter' );
 						echo '</option>';
 				}
 
@@ -101,7 +101,7 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 	<table class="form-table" id="bsf-rt-progress-bar-options" <?php echo wp_kses_post( $bsf_rt_progress_display ); ?>>  
 		<tr>
 	<th scope="row"> 
-			<label for="ProgressBarStyle"><?php esc_attr_e( 'Styles', 'bsf_rt_textdomain' ); ?> :</label>
+			<label for="ProgressBarStyle"><?php esc_html_e( 'Styles:', 'read-meter' ); ?></label>
 	</th>
 			<td>
 			<select  name="bsf_rt_progress_bar_styles" id="bsf_rt_progress_bar_styles">
@@ -111,34 +111,34 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 						if ( 'Normal' === $bsf_rt_progress_bar_styles ) {
 
 							echo '<option id="normalcolor" selected value="Normal">';
-							esc_attr_e( 'Normal', 'bsf_rt_textdomain' );
+							esc_html_e( 'Normal', 'read-meter' );
 							echo '</option>';
 
 						} else {
 
 							echo '<option id="normalcolor"  value="Normal">';
-							esc_attr_e( 'Normal', 'bsf_rt_textdomain' );
+							esc_html_e( 'Normal', 'read-meter' );
 							echo '</option>';
 						}
 						if ( 'Gradient' === $bsf_rt_progress_bar_styles ) {
 
 							echo '<option selected id="gradiantcolor" value="Gradient">';
-							esc_attr_e( 'Gradient', 'bsf_rt_textdomain' );
+							esc_html_e( 'Gradient', 'read-meter' );
 							echo '</option>';
 
 						} else {
 
 							echo '<option  id="gradiantcolor" value="Gradient">';
-							esc_attr_e( 'Gradient', 'bsf_rt_textdomain' );
+							esc_html_e( 'Gradient', 'read-meter' );
 							echo '</option>';
 						}
 					} else {
 
 							echo '<option id="normalcolor"  value="Normal">';
-							esc_attr_e( 'Normal', 'bsf_rt_textdomain' );
+							esc_html_e( 'Normal', 'read-meter' );
 							echo '</option>';
 							echo '<option  id="gradiantcolor" value="Gradient">';
-							esc_attr_e( 'Gradient', 'bsf_rt_textdomain' );
+							esc_html_e( 'Gradient', 'read-meter' );
 							echo '</option>';
 					}
 
@@ -149,7 +149,7 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 		<tr id="normal-back-wrap">
 			<th scope="row">
 
-			<label for="ProgressBarBackgroundColor"><?php esc_attr_e( 'Background Color', 'bsf_rt_textdomain' ); ?> :</label>
+			<label for="ProgressBarBackgroundColor"><?php esc_html_e( 'Background Color:', 'read-meter' ); ?></label>
 
 			</th>
 			<td>
@@ -171,7 +171,7 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 		</tr> 
 		<tr id="normal-color-wrap">
 			<th scope="row">
-			<label for="ProgressBarColor"> <?php esc_attr_e( 'Primary Color', 'bsf_rt_textdomain' ); ?> :</label>
+			<label for="ProgressBarColor"> <?php esc_html_e( 'Primary Color:', 'read-meter' ); ?></label>
 			</th>  
 			<td>
 				<?php
@@ -193,7 +193,7 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 		</tr>
 		<tr id="gradiant-wrap2" <?php echo wp_kses_post( $bsf_rt_progress_color_display ); ?>>
 			<th scope="row">
-				<label for="ProgressBarColor"> <?php esc_attr_e( 'Secondary Color', 'bsf_rt_textdomain' ); ?> :</label>
+				<label for="ProgressBarColor"> <?php esc_html_e( 'Secondary Color:', 'read-meter' ); ?></label>
 			</th>
 			<td>
 					<?php
@@ -213,7 +213,7 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 		<tr>
 			<th scope="row">
 
-			<label for="Thickness"><?php esc_attr_e( 'Bar Thickness', 'bsf_rt_textdomain' ); ?> :</label>
+			<label for="Thickness"><?php esc_html_e( 'Bar Thickness:', 'read-meter' ); ?></label>
 
 			</th>
 			<td>
@@ -240,7 +240,7 @@ $bsf_rt_progress_color_display = ( ( 'Normal' === $bsf_rt_progress_bar_styles ) 
 	<tr>
 			<th>
 				<?php wp_nonce_field( 'bsf-rt-nonce-progress', 'bsf-rt-progress' ); ?>
-			<input type="submit" value="Save" class="bt button button-primary" name="submit">
+			<input type="submit" value="<?php esc_attr_e( 'Save', 'read-meter' ); ?>" class="bt button button-primary" name="submit">
 
 			</th>
 		</tr>

--- a/includes/bsf-rt-read-time-settings.php
+++ b/includes/bsf-rt-read-time-settings.php
@@ -56,11 +56,11 @@ $bsf_rt_read_time_options_display = ( ( 'none' === $bsf_rt_position_of_read_time
 <table class="form-table" >
 <br>     
 <p class="description">
-<?php esc_attr_e( 'Control the position & appearance of the estimated read time of the post.', 'read-meter' ); ?>
+<?php esc_html_e( 'Control the position & appearance of the estimated read time of the post.', 'read-meter' ); ?>
 </p> 
 <tr>
 <th scope="row">
-<label for="ShowEstimatedReadTime"><?php esc_attr_e( 'Show Estimated Read Time On', 'read-meter' ); ?>:</label>
+<label for="ShowEstimatedReadTime"><?php esc_html_e( 'Show Estimated Read Time On', 'read-meter' ); ?>:</label>
 </th>
 <td>
 <label id="bsf_rt_single_checkbox_label" for="ForSinglePage" class="bsf_rt_show_readtime_label" >
@@ -76,7 +76,7 @@ if ( isset( $bsf_rt_show_read_time ) && is_array( $bsf_rt_show_read_time ) ) {
 	echo '  <input id="bsf_rt_single_page" type="checkbox" checked name="bsf_rt_show_read_time[]"  value="bsf_rt_single_page">';
 }
 ?>
-<?php esc_attr_e( 'Single Post', 'read-meter' ); ?>
+<?php esc_html_e( 'Single Post', 'read-meter' ); ?>
 </label> 
 
 <br>
@@ -88,7 +88,7 @@ if ( isset( $bsf_rt_show_read_time ) && is_array( $bsf_rt_show_read_time ) && in
 	echo '  <input id="bsf_rt_home_blog_page" type="checkbox" name="bsf_rt_show_read_time[]" value="bsf_rt_home_blog_page" >';
 }
 ?>
-<?php esc_attr_e( 'Home / Blog Page', 'read-meter' ); ?>
+<?php esc_html_e( 'Home / Blog Page', 'read-meter' ); ?>
 </label> 
 
 <br>
@@ -100,7 +100,7 @@ if ( isset( $bsf_rt_show_read_time ) && is_array( $bsf_rt_show_read_time ) && in
 	echo ' <input id="bsf_rt_archive_page"  type="checkbox" name="bsf_rt_show_read_time[]" value="bsf_rt_archive_page" >';
 }
 ?>
-<?php esc_attr_e( 'Archive Page', 'read-meter' ); ?>
+<?php esc_html_e( 'Archive Page', 'read-meter' ); ?>
 </label> 
 
 
@@ -109,7 +109,7 @@ if ( isset( $bsf_rt_show_read_time ) && is_array( $bsf_rt_show_read_time ) && in
 </tr>
 <tr>
 <th scope="row">
-<label for="ShowReadTimePosition"> <?php esc_attr_e( 'Read Time Position', 'read-meter' ); ?> :</label>
+<label for="ShowReadTimePosition"> <?php esc_html_e( 'Read Time Position:', 'read-meter' ); ?></label>
 </th>
 <td>
 <select id="bsf_rt_position_of_read_time" required name="bsf_rt_position_of_read_time" >
@@ -117,53 +117,53 @@ if ( isset( $bsf_rt_show_read_time ) && is_array( $bsf_rt_show_read_time ) && in
 if ( isset( $bsf_rt_position_of_read_time ) ) {
 	if ( 'above_the_content' === $bsf_rt_position_of_read_time ) {
 		echo '<option selected value="above_the_content">';
-		esc_attr_e( 'Above the Content', 'read-meter' );
+		esc_html_e( 'Above the Content', 'read-meter' );
 		echo '</option>';
 	} else {
 		echo '<option value="above_the_content">';
-		esc_attr_e( 'Above the Content', 'read-meter' );
+		esc_html_e( 'Above the Content', 'read-meter' );
 		echo '</option>';                }
 	if ( 'above_the_post_title' === $bsf_rt_position_of_read_time ) {
 
 		echo '<option selected value="above_the_post_title">';
-		esc_attr_e( 'Above the Post Title', 'read-meter' );
+		esc_html_e( 'Above the Post Title', 'read-meter' );
 		echo '</option>';
 	} else {
 		echo '<option  value="above_the_post_title">';
-		esc_attr_e( 'Above the Post Title', 'read-meter' );
+		esc_html_e( 'Above the Post Title', 'read-meter' );
 		echo '</option>';
 	}
 	if ( 'below_the_post_title' === $bsf_rt_position_of_read_time ) {
 		echo '<option selected value="below_the_post_title">';
-		esc_attr_e( 'Below the Post Title', 'read-meter' );
+		esc_html_e( 'Below the Post Title', 'read-meter' );
 		echo '</option>';
 	} else {
 		echo '<option  value="below_the_post_title">';
-		esc_attr_e( 'Below the Post Title', 'read-meter' );
+		esc_html_e( 'Below the Post Title', 'read-meter' );
 		echo '</option>';
 	}
 	if ( 'none' === $bsf_rt_position_of_read_time ) {
 		echo '<option selected value="none">';
-		esc_attr_e( 'None', 'read-meter' );
+		esc_html_e( 'None', 'read-meter' );
 		echo '</option>';
 	} else {
 		echo '<option  value="none">';
-		esc_attr_e( 'None', 'read-meter' );
+		esc_html_e( 'None', 'read-meter' );
 		echo '</option>';
 	}
 } else {
 
 	echo '<option value="above_the_content">';
-	esc_attr_e( 'Above the Content', 'read-meter' );
+	esc_html_e( 'Above the Content', 'read-meter' );
 	echo '</option>';
 	echo '<option  value="above_the_post_title">';
-	esc_attr_e( 'Above the Post Title', 'read-meter' );
+	esc_html_e( 'Above the Post Title', 'read-meter' );
 	echo '</option>';
 	echo '<option  value="below_the_post_title">';
-	esc_attr_e( 'Below the Post Title', 'read-meter' );
+	esc_html_e( 'Below the Post Title', 'read-meter' );
 	echo '</option>';
 	echo '<option  value="none">';
-	esc_attr_e( 'None', 'read-meter' );
+	esc_html_e( 'None', 'read-meter' );
 	echo '</option>';
 
 }
@@ -177,7 +177,7 @@ if ( isset( $bsf_rt_position_of_read_time ) ) {
 
 <tr>
 <th scope="row">
-<label for="ReadingTimePrefixLabel"> <?php esc_attr_e( 'Reading Time Prefix', 'read-meter' ); ?> :</label>
+<label for="ReadingTimePrefixLabel"> <?php esc_html_e( 'Reading Time Prefix:', 'read-meter' ); ?></label>
 </th>
 <td>
 <?php
@@ -185,11 +185,11 @@ if ( isset( $bsf_rt_reading_time_label ) ) {
 	echo '<input type="text"  name="bsf_rt_reading_time_prefix_label"  value="' . esc_attr( $bsf_rt_reading_time_label ) . '" class="regular-text">';
 } else {
 	?>
-<input type="text"  name="bsf_rt_reading_time_prefix_label" value="Reading Time" class="regular-text">
+<input type="text"  name="bsf_rt_reading_time_prefix_label" value="<?php esc_attr_e( 'Reading Time', 'read-meter' ); ?>" class="regular-text">
 <?php } ?>
 
 <p class="description">
-<?php esc_attr_e( 'This text will display before the Reading Time.', 'read-meter' ); ?>
+<?php esc_html_e( 'This text will display before the Reading Time.', 'read-meter' ); ?>
 
 
 </p>  
@@ -197,7 +197,7 @@ if ( isset( $bsf_rt_reading_time_label ) ) {
 </tr>
 <tr>
 <th scope="row">
-<label for="ReadingTimePrefixLabel"><?php esc_attr_e( 'Reading Time Postfix', 'read-meter' ); ?> :</label>
+<label for="ReadingTimePrefixLabel"><?php esc_html_e( 'Reading Time Postfix:', 'read-meter' ); ?></label>
 </th>
 <td>
 <?php
@@ -205,31 +205,31 @@ if ( isset( $bsf_rt_reading_time_postfix_label ) ) {
 	echo '<input type="text"  name="bsf_rt_reading_time_postfix_label"  value="' . esc_attr( $bsf_rt_reading_time_postfix_label ) . '" class="regular-text">';
 } else {
 	?>
-<input type="text"  name="bsf_rt_reading_time_postfix_label" value="mins" class="regular-text">
+<input type="text"  name="bsf_rt_reading_time_postfix_label" value="<?php esc_attr_e( 'mins', 'read-meter' ); ?>" class="regular-text">
 <?php } ?>
 <p class="description">  
-<?php esc_attr_e( 'This text will display after the Reading Time.', 'read-meter' ); ?>                  
+<?php esc_html_e( 'This text will display after the Reading Time.', 'read-meter' ); ?>                  
 
 </p>  
 </td>
 </tr>
 <tr >
 <th scope="row">
-<label for="ReadtimeFontSize"><?php esc_attr_e( 'Font Size', 'read-meter' ); ?>  :</label>
+<label for="ReadtimeFontSize"><?php esc_html_e( 'Font Size:', 'read-meter' ); ?></label>
 </th>
 <td>
 <?php
 echo '<input type="number" name="bsf_rt_read_time_font_size" max="50" min="10" class="small-text" value="' . esc_attr( $bsf_rt_read_time_font_size ) . '"  >&nbsp px';
 ?>
 <p class="description">
-<?php esc_attr_e( 'Keep blank for default value.', 'read-meter' ); ?>                  
+<?php esc_html_e( 'Keep blank for default value.', 'read-meter' ); ?>                  
 
 </p>  
 </td>
 </tr>
 <tr>
 <th scope="row">
-<label for="ReadingTimeMargin"><?php esc_attr_e( 'Margin', 'read-meter' ); ?> :</label>
+<label for="ReadingTimeMargin"><?php esc_html_e( 'Margin:', 'read-meter' ); ?></label>
 </th>
 <td>
 <?php
@@ -257,16 +257,16 @@ if ( 'em' === $bsf_rt_margin_unit ) {
 ?>
 </select>
 <p class="description bsf-rt-label-style">
-<label class="bsf-rt-top">TOP</label>
-<label class="bsf-rt-right">RIGHT</label>
-<label class="bsf-rt-bottom">BOTTOM</label>
-<label class="bsf-rt-left">LEFT</label>                  
+<label class="bsf-rt-top"><?php esc_html_e( 'TOP', 'read-meter' ); ?></label>
+<label class="bsf-rt-right"><?php esc_html_e( 'RIGHT', 'read-meter' ); ?></label>
+<label class="bsf-rt-bottom"><?php esc_html_e( 'BOTTOM', 'read-meter' ); ?></label>
+<label class="bsf-rt-left"><?php esc_html_e( 'LEFT', 'read-meter' ); ?></label>                  
 </p> 
 </td> 
 </tr>
 <tr>
 <th scope="row">
-<label for="ReadingTimePadding"><?php esc_attr_e( 'Padding', 'read-meter' ); ?> :</label>
+<label for="ReadingTimePadding"><?php esc_html_e( 'Padding:', 'read-meter' ); ?></label>
 </th>
 <td>
 <?php
@@ -294,16 +294,16 @@ if ( 'em' === $bsf_rt_padding_unit ) {
 ?>
 </select>
 <p class="description bsf-rt-label-style">
-<label class="bsf-rt-top">TOP</label>
-<label class="bsf-rt-right">RIGHT</label>
-<label class="bsf-rt-bottom">BOTTOM</label>
-<label class="bsf-rt-left">LEFT</label>                  
+<label class="bsf-rt-top"><?php esc_html_e( 'TOP', 'read-meter' ); ?></label>
+<label class="bsf-rt-right"><?php esc_html_e( 'RIGHT', 'read-meter' ); ?></label>
+<label class="bsf-rt-bottom"><?php esc_html_e( 'BOTTOM', 'read-meter' ); ?></label>
+<label class="bsf-rt-left"><?php esc_html_e( 'LEFT', 'read-meter' ); ?></label>                  
 </p> 
 </td>
 </tr> 
 <tr>
 <th scope="row"> 
-<label for="ReadtimeBackgroundColor"> <?php esc_attr_e( 'Background Color', 'read-meter' ); ?> :</label>
+<label for="ReadtimeBackgroundColor"> <?php esc_html_e( 'Background Color:', 'read-meter' ); ?></label>
 </th>
 <td>
 <?php
@@ -323,7 +323,7 @@ echo '</div>';
 </tr> 
 <tr >
 <th scope="row">
-<label for="ReadTimeColor"> <?php esc_attr_e( 'Text Color', 'read-meter' ); ?> :</label>
+<label for="ReadTimeColor"> <?php esc_html_e( 'Text Color:', 'read-meter' ); ?></label>
 </th>  
 <td>
 <?php
@@ -345,7 +345,7 @@ if ( isset( $bsf_rt_read_time_color ) ) {
 <tr>
 <th>
 <?php wp_nonce_field( 'bsf-rt-nonce-reading', 'bsf-rt-reading' ); ?>
-<input type="submit" value="Save" class="bt button button-primary" name="submit">
+<input type="submit" value="<?php esc_attr_e( 'Save', 'read-meter' ); ?>" class="bt button button-primary" name="submit">
 </th>
 </tr>
 </table>

--- a/includes/bsf-rt-user-manual.php
+++ b/includes/bsf-rt-user-manual.php
@@ -12,14 +12,13 @@ wp_enqueue_style( 'bsfrt_dashboard' );
 ?>
 <div class="bsf_rt_user_manual">
 	<br><label class="bsf_rt_page_title" for="howtouse">
-		<?php
-		echo 'How to Use? </label><br><br>
-	<b>Step 1</b> :Under the <i>General Settings</i> Tab, select post types to display the Read Time and Progress bar. Select Words Per Minute and set other options if required. <br><br>
-	<b>Step 2</b> : Go to the <i>Read Time</i> Tab, and select target pages. Set position, prefix, postfix, and other styling options. <br><br>
-	<b>Step 3</b> : Go to the <i>Progress Bar</i> Tab, and select the position, colors, and thickness of the progress bar as per your need. <br><br>
-	<b>Step 4</b> :That' . "'" . 's it! Visit Post/Page to see results.  <br><br><br>
-	<b> Shortcode : [read_meter]</b> <br><br>
-		You can also display the reading time wherever you want by using this shortcode , You just need to copy it and paste it in any content of Post or Page. <br>
-		You can provide a simple ID attribute to the shortcode to display reading time of that particular post/page irrespective of where the shortcode is added, eg: <b>[read_meter id=47]</b>.';
-		?>
+		<?php esc_html_e( 'How to Use?', 'read-meter' ); ?>
+		</label><br><br>
+	<?php printf(esc_html__( '%1$sStep 1:%2$s Under the %1$sGeneral Settings%2$s Tab, select post types to display the Read Time and Progress bar. Select Words Per Minute and set other options if required.', 'read-meter' ),'<strong>','</strong>'); ?><br><br>
+	<?php printf(esc_html__( '%1$sStep 2:%2$s Go to the %1$sRead Time%2$s Tab, and select target pages. Set position, prefix, postfix, and other styling options.', 'read-meter' ),'<strong>','</strong>'); ?><br><br>
+	<?php printf(esc_html__( '%1$sStep 3:%2$s Go to the %1$sProgress Bar%2$s Tab, and select the position, colors, and thickness of the progress bar as per your need.', 'read-meter' ),'<strong>','</strong>'); ?><br><br>
+	<?php printf(esc_html__( '%1$sStep 4:%2$s That\'s it! Visit Post/Page to see results.', 'read-meter' ),'<strong>','</strong>'); ?><br><br><br>
+	<b><?php esc_html_e( 'Shortcode : [read_meter]', 'read-meter' ); ?></b> <br><br>
+		<?php esc_html_e( 'You can also display the reading time wherever you want by using this shortcode , You just need to copy it and paste it in any content of Post or Page.', 'read-meter' ); ?><br>
+		<?php printf(esc_html__( 'You can provide a simple ID attribute to the shortcode to display reading time of that particular post/page irrespective of where the shortcode is added, eg: %1$s[read_meter id=47]%2$s.', 'read-meter' ),'<strong>','</strong>'); ?>
 </div>


### PR DESCRIPTION
- Delete the Plugin Name header's dot at the end.
- Modify the current text domain to equal the plugin slug. The current text domain is end of dot, which is incorrect, and the correct text domain should be `read-meter` (without dot).
- Adding necessary text domain for localizable strings.
- Fix wrong text domain from `bsf_rt_textdomain` to `read-meter`.